### PR TITLE
[PXS-80852] Upgrade Scala-xml to v2.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 organization in ThisBuild          := "net.liftweb"
 
-version in ThisBuild               :=  "2.6.3-px"
+version in ThisBuild               :=  "2.6.3-px-1"
 
 homepage in ThisBuild              := Some(url("http://www.liftweb.net"))
 

--- a/core/json/src/main/scala/net/liftweb/json/Xml.scala
+++ b/core/json/src/main/scala/net/liftweb/json/Xml.scala
@@ -187,7 +187,7 @@ object Xml {
     }
   }
 
-  private[json] class XmlNode(name: String, children: Seq[Node]) extends Elem(null, name, xml.Null, TopScope, children :_*)
+  private[json] class XmlNode(name: String, children: Seq[Node]) extends Elem(null, name, xml.Null, TopScope, minimizeEmpty = false, children :_*)
 
-  private[json] class XmlElem(name: String, value: String) extends Elem(null, name, xml.Null, TopScope, Text(value))
+  private[json] class XmlElem(name: String, value: String) extends Elem(null, name, xml.Null, TopScope, minimizeEmpty = false, Text(value))
 }

--- a/core/util/src/main/scala/net/liftweb/util/BindHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/BindHelpers.scala
@@ -166,6 +166,7 @@ trait BindHelpers {
                  elem.label,
                  fix(elem.attributes),
                  elem.scope,
+                 elem.minimizeEmpty,
                  elem.child :_*)
       }
       case _ => elem % new UnprefixedAttribute("class", cssClass, Null)
@@ -842,7 +843,7 @@ trait BindHelpers {
             else
               Text("FIX"+"ME failed to bind <"+namespace+":"+node.label+" />")
           case Group(nodes) => Group(rec_xbind(nodes))
-          case s: Elem => Elem(node.prefix, node.label, node.attributes, node.scope, rec_xbind(node.child): _*)
+          case s: Elem => Elem(node.prefix, node.label, node.attributes, node.scope, minimizeEmpty = false, rec_xbind(node.child): _*)
           case n => node
         }
       }
@@ -959,10 +960,11 @@ trait BindHelpers {
             val fixedLabel = av.substring(nsColon.length)
 
             val fake = new Elem(namespace, fixedLabel, fixedAttrs,
-                                e.scope, new Elem(e.namespace,
+                                e.scope, e.minimizeEmpty, new Elem(e.namespace,
                                                   e.label,
                                                   fixedAttrs,
                                                   e.scope,
+                                                  e.minimizeEmpty,
                                                   e.child :_*))
 
             BindHelpers._currentNode.doWith(fake) {
@@ -1101,7 +1103,7 @@ trait BindHelpers {
           }
         }
         case Group(nodes) => Group(bind(vals, nodes))
-        case s: Elem => Elem(node.prefix, node.label, node.attributes, node.scope, bind(vals, node.child, false, unusedBindings): _*)
+        case s: Elem => Elem(node.prefix, node.label, node.attributes, node.scope, minimizeEmpty = false, bind(vals, node.child, false, unusedBindings): _*)
         case n => node
       }
     }
@@ -1150,7 +1152,7 @@ trait BindHelpers {
               case _ => None
             }.getOrElse(processBind(v.asInstanceOf[Elem].child, atWhat))
 
-          case e: Elem => {Elem(e.prefix, e.label, e.attributes, e.scope, processBind(e.child, atWhat): _*)}
+          case e: Elem => {Elem(e.prefix, e.label, e.attributes, e.scope, e.minimizeEmpty, processBind(e.child, atWhat): _*)}
           case _ => {v}
         }
 
@@ -1256,7 +1258,7 @@ trait BindHelpers {
 
         new Elem(e.prefix,
                  e.label, new UnprefixedAttribute("id", id, meta),
-                 e.scope, e.child :_*)
+                 e.scope, e.minimizeEmpty, e.child :_*)
       }
 
       case x => x
@@ -1334,7 +1336,7 @@ trait BindHelpers {
                    in.label, in.attributes.filter {
                      case up: UnprefixedAttribute => up.key != "id"
                      case _ => true
-                   }, in.scope, in.child :_*)
+                   }, in.scope, in.minimizeEmpty, in.child :_*)
           } else {
             ids += id.text
             in
@@ -1372,12 +1374,12 @@ trait BindHelpers {
                        in.label, in.attributes.filter {
                          case up: UnprefixedAttribute => up.key != "id"
                          case _ => true
-                       }, in.scope, in.child.map(ensure) :_*)
+                       }, in.scope, in.minimizeEmpty, in.child.map(ensure) :_*)
             } else {
               ids += id.text
               new Elem(in.prefix,
                        in.label, in.attributes,
-                       in.scope, in.child.map(ensure) :_*)
+                       in.scope, in.minimizeEmpty, in.child.map(ensure) :_*)
             }
 
           }
@@ -1385,7 +1387,7 @@ trait BindHelpers {
           case _ =>
             new Elem(in.prefix,
                      in.label, in.attributes,
-                     in.scope, in.child.map(ensure) :_*)
+                     in.scope, in.minimizeEmpty, in.child.map(ensure) :_*)
         }
 
       case x => x

--- a/core/util/src/main/scala/net/liftweb/util/BindHelpers.scala
+++ b/core/util/src/main/scala/net/liftweb/util/BindHelpers.scala
@@ -997,7 +997,7 @@ trait BindHelpers {
             }
           }
           case Group(nodes) => Group(in_bind(nodes))
-          case s: Elem => Elem(s.prefix, s.label, attrBind(s.attributes), if (preserveScope) s.scope else TopScope,
+          case s: Elem => Elem(s.prefix, s.label, attrBind(s.attributes), if (preserveScope) s.scope else TopScope, minimizeEmpty = false,
                                in_bind(s.child): _*)
           case n => n
         }

--- a/core/util/src/main/scala/net/liftweb/util/CssSel.scala
+++ b/core/util/src/main/scala/net/liftweb/util/CssSel.scala
@@ -243,7 +243,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
 
             new Elem(elem.prefix,
               elem.label, newAttr,
-              elem.scope, elem.child: _*)
+              elem.scope, minimizeEmpty = false, elem.child: _*)
 
           }
         }
@@ -279,7 +279,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
 
             new Elem(elem.prefix,
               elem.label, newAttr,
-              elem.scope, elem.child: _*)
+              elem.scope, minimizeEmpty = false, elem.child: _*)
 
           }
         }
@@ -374,13 +374,13 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
         case Full(todo: WithKids) => {
           val calced = bind.calculate(realE.child)
           calced.length match {
-            case 0 => new Elem(realE.prefix, realE.label, realE.attributes, realE.scope)
+            case 0 => new Elem(realE.prefix, realE.label, realE.attributes, realE.scope, minimizeEmpty = false)
             case 1 => new Elem(realE.prefix, realE.label,
-              realE.attributes, realE.scope,
+              realE.attributes, realE.scope, minimizeEmpty = false,
               todo.transform(realE.child, calced.head): _*)
             case _ if id.isEmpty =>
               calced.map(kids => new Elem(realE.prefix, realE.label,
-                realE.attributes, realE.scope,
+                realE.attributes, realE.scope, minimizeEmpty = false,
                 todo.transform(realE.child, kids): _*))
 
             case _ => {
@@ -388,11 +388,11 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
               calced.toList.zipWithIndex.map {
                 case (kids, 0) =>
                   new Elem(realE.prefix, realE.label,
-                    realE.attributes, realE.scope,
+                    realE.attributes, realE.scope, minimizeEmpty = false,
                     todo.transform(realE.child, kids): _*)
                 case (kids, _) =>
                   new Elem(realE.prefix, realE.label,
-                    noId, realE.scope,
+                    noId, realE.scope, minimizeEmpty = false,
                     todo.transform(realE.child, kids): _*)
               }
             }
@@ -409,7 +409,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
                 case Group(g) => g
                 case e: Elem => new Elem(e.prefix,
                   e.label, mergeAll(e.attributes, false, x == Full(DontMergeAttributes)),
-                  e.scope, e.child: _*)
+                  e.scope, minimizeEmpty = false, e.child: _*)
                 case x => x
               }
             }
@@ -431,7 +431,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
                         id => ids.contains(id)
                       } getOrElse (false)
                       val newIds = targetId filter (_ => keepId) map (i => ids - i) getOrElse (ids)
-                      val newElem = new Elem(e.prefix, e.label, mergeAll(e.attributes, !keepId, x == Full(DontMergeAttributes)), e.scope, e.child: _*)
+                      val newElem = new Elem(e.prefix, e.label, mergeAll(e.attributes, !keepId, x == Full(DontMergeAttributes)), e.scope, minimizeEmpty = false, e.child: _*)
                       (newIds, newElem :: result)
                     }
                     case x => (ids, x :: result)
@@ -570,7 +570,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
     } else {
       lb.toList.filterNot(_.selectThis_?) match {
         case Nil => new Elem(e.prefix, e.label,
-          e.attributes, e.scope, run(e.child, onlySel, depth + 1): _*)
+          e.attributes, e.scope, minimizeEmpty = false, run(e.child, onlySel, depth + 1): _*)
         case csb =>
           // do attributes first, then the body
           csb.partition(_.attrSel_?) match {
@@ -578,7 +578,7 @@ private class SelectorMap(binds: List[CssBind]) extends Function1[NodeSeq, NodeS
             case (attrs, Nil) => {
               val elem = slurp.applyAttributeRules(attrs, e)
               new Elem(elem.prefix, elem.label,
-                elem.attributes, elem.scope, run(elem.child, onlySel, depth + 1): _*)
+                elem.attributes, elem.scope, minimizeEmpty = false, run(elem.child, onlySel, depth + 1): _*)
             }
 
             case (attrs, rules) => {

--- a/core/util/src/main/scala/net/liftweb/util/CssSelector.scala
+++ b/core/util/src/main/scala/net/liftweb/util/CssSelector.scala
@@ -92,7 +92,7 @@ final case class SurroundKids() extends SubNode with WithKids {
         changed = true
         new Elem(e.prefix,
           e.label, e.attributes,
-          e.scope, e.child ++ original :_*)
+          e.scope, e.minimizeEmpty, e.child ++ original :_*)
       case x => x
     }
 

--- a/core/util/src/main/scala/net/liftweb/util/HeadHelper.scala
+++ b/core/util/src/main/scala/net/liftweb/util/HeadHelper.scala
@@ -85,16 +85,16 @@ object HeadHelper {
     } else {
       def xform(in: NodeSeq, inBody: Boolean): NodeSeq = in flatMap {
         case e: Elem if !inBody && e.label == "body" =>
-          Elem(e.prefix, e.label, e.attributes, e.scope, xform(e.child, true) :_*)
+          Elem(e.prefix, e.label, e.attributes, e.scope, e.minimizeEmpty, xform(e.child, true) :_*)
 
         case e: Elem if inBody && e.label == "head" => NodeSeq.Empty
 
         case e: Elem if e.label == "head" =>
           Elem(e.prefix, e.label, e.attributes,
-               e.scope, removeHtmlDuplicates(e.child ++ headInBody) :_*)
+               e.scope, e.minimizeEmpty, removeHtmlDuplicates(e.child ++ headInBody) :_*)
 
         case e: Elem =>
-          Elem(e.prefix, e.label, e.attributes, e.scope, xform(e.child, inBody) :_*)
+          Elem(e.prefix, e.label, e.attributes, e.scope, e.minimizeEmpty, xform(e.child, inBody) :_*)
 
         case g: Group =>
           xform(g.child, inBody)

--- a/core/util/src/main/scala/net/liftweb/util/HtmlParser.scala
+++ b/core/util/src/main/scala/net/liftweb/util/HtmlParser.scala
@@ -363,20 +363,20 @@ trait Html5Parser {
           if (capture) {
             val text = buffer.toString()
             if (text.length() > 0) {
-              hStack.push(createText(text))
+              hStack = createText(text) :: hStack
             }
           }
           buffer.setLength(0)
         }
       }
 
-      saxer.scopeStack.push(TopScope)
+      saxer.scopeStack = TopScope :: saxer.scopeStack
       hp.setContentHandler(saxer)
       val is = new InputSource(in)
       is.setEncoding("UTF-8")
       hp.parse(is)
 
-      saxer.scopeStack.pop
+      saxer.scopeStack = saxer.scopeStack.tail
 
       in.close()
       saxer.rootElem match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   lazy val scalaz7_core: ModuleMap = sv => scalazGroup(sv)       % "scalaz-core"        % scalaz7Version(sv) cross CVMappingScalaz
   lazy val slf4j_api              = "org.slf4j"                  % "slf4j-api"          % slf4jVersion
   lazy val squeryl                = "org.squeryl"                % "squeryl"            % "0.9.5-7" cross CVMappingAll
-  lazy val scala_xml              = "org.scala-lang.modules"     %% "scala-xml"         % "1.3.0"
+  lazy val scala_xml              = "org.scala-lang.modules"     %% "scala-xml"         % "2.3.0"
   lazy val scala_parser           = "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.1.2"
   lazy val xerces                 = "xerces" % "xercesImpl" % "2.11.0"
 

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/A.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/A.scala
@@ -41,7 +41,7 @@ object A extends DispatchSnippet {
    *   }
    *   </pre>
    */
-  def render(kids: NodeSeq) : NodeSeq = Elem(null, "a", addAjaxHREF(), TopScope, kids :_*)
+  def render(kids: NodeSeq) : NodeSeq = Elem(null, "a", addAjaxHREF(), TopScope, minimizeEmpty = false, kids :_*)
 
   private def addAjaxHREF(): MetaData = {
     val ajax: JsExp = SHtml.makeAjaxCall(JE.Str(S.attr.~("key").map(_.text + "=true").getOrElse("")))

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Comet.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Comet.scala
@@ -60,7 +60,7 @@ object Comet extends DispatchSnippet with LazyLoggable {
 
   private def buildSpan(timeb: Box[Long], xml: NodeSeq, cometActor: LiftCometActor, spanId: String): NodeSeq =
   Elem(cometActor.parentTag.prefix, cometActor.parentTag.label, cometActor.parentTag.attributes,
-       cometActor.parentTag.scope, Group(xml)) %
+       cometActor.parentTag.scope, cometActor.parentTag.minimizeEmpty, Group(xml)) %
   (new UnprefixedAttribute("id", Text(spanId), Null)) %
   (timeb.filter(_ > 0L).map(time => (new PrefixedAttribute("lift", "when", Text(time.toString), Null))) openOr Null)
 

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Form.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Form.scala
@@ -65,7 +65,7 @@ object Form extends DispatchSnippet {
                                             up.key != "method" && up.key != "action"
                                           case x => true
                                         }))
-            new Elem(null, "form", meta , e.scope, e.child :_*)
+            new Elem(null, "form", meta , e.scope, e.minimizeEmpty, e.child :_*)
           } else {
             <form method="post" action={S.uri}>{kids}</form>
           }
@@ -85,9 +85,9 @@ object Form extends DispatchSnippet {
         kids(0).isInstanceOf[Elem] && 
         (kids(0).prefix eq null) &&
         kids(0).label == "form") {
-      new Elem(null, "form", addAjaxForm , TopScope, kids(0).child :_*)
+      new Elem(null, "form", addAjaxForm , TopScope, minimizeEmpty = false, kids(0).child :_*)
     } else {
-      Elem(null, "form", addAjaxForm, TopScope, kids : _*)
+      Elem(null, "form", addAjaxForm, TopScope, minimizeEmpty = false, kids : _*)
     }
   }
 

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Menu.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Menu.scala
@@ -143,7 +143,7 @@ object Menu extends DispatchSnippet {
 
             case m@MenuItem(text, uri, kids, _, _, _) if m.placeholder_? =>
               Helpers.addCssClass(i.cssClass,
-                                  Elem(null, innerTag, Null, TopScope,
+                                  Elem(null, innerTag, Null, TopScope, minimizeEmpty = false,
                                        // Is a placeholder useful if we don't display the kids? I say no (DCB, 20101108)
                                        <xml:group> <span>{text}</span>{buildUlLine(kids)}</xml:group>) %
                                   (if (m.path) S.prefixedAttrsToMetaData("li_path", liMap) else Null) %
@@ -151,26 +151,26 @@ object Menu extends DispatchSnippet {
 
             case MenuItem(text, uri, kids, true, _, _) if linkToSelf =>
               Helpers.addCssClass(i.cssClass,
-                                  Elem(null, innerTag, Null, TopScope,
+                                  Elem(null, innerTag, Null, TopScope, minimizeEmpty = false,
                                        <xml:group> <a href={uri}>{text}</a>{ifExpandCurrent(buildUlLine(kids))}</xml:group>) %
                                   S.prefixedAttrsToMetaData("li_item", liMap))
 
             case MenuItem(text, uri, kids, true, _, _) =>
               Helpers.addCssClass(i.cssClass,
-                                  Elem(null, innerTag, Null, TopScope,
+                                  Elem(null, innerTag, Null, TopScope, minimizeEmpty = false,
                                        <xml:group> <span>{text}</span>{ifExpandCurrent(buildUlLine(kids))}</xml:group>) %
                                   S.prefixedAttrsToMetaData("li_item", liMap))
 
             // Not current, but on the path, so we need to expand children to show the current one
             case MenuItem(text, uri, kids, _, true, _) =>
               Helpers.addCssClass(i.cssClass,
-                                  Elem(null, innerTag, Null, TopScope,
+                                  Elem(null, innerTag, Null, TopScope, minimizeEmpty = false,
                                        <xml:group> <a href={uri}>{text}</a>{buildUlLine(kids)}</xml:group>) %
                                   S.prefixedAttrsToMetaData("li_path", liMap))
 
             case MenuItem(text, uri, kids, _, _, _) =>
               Helpers.addCssClass(i.cssClass,
-                                  Elem(null, innerTag, Null, TopScope,
+                                  Elem(null, innerTag, Null, TopScope, minimizeEmpty = false,
                                        <xml:group> <a href={uri}>{text}</a>{ifExpandAll(buildUlLine(kids))}</xml:group>) % li)
           }
         }
@@ -180,7 +180,7 @@ object Menu extends DispatchSnippet {
             NodeSeq.Empty
           } else {
             if (outerTag.length > 0) {
-              Elem(null, outerTag, Null, TopScope,
+              Elem(null, outerTag, Null, TopScope, minimizeEmpty = false,
                 <xml:group>{in.flatMap(buildANavItem)}</xml:group>) %
                   S.prefixedAttrsToMetaData("ul")
             } else {

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Tail.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/Tail.scala
@@ -54,6 +54,7 @@ object Head extends DispatchSnippet {
                     e.label,
                     e.attributes,
                     e.scope,
+                    e.minimizeEmpty,
                     validHeadTagsOnly(e.child) :_*)
          }
          case e: Elem if (null eq e.prefix) => NodeSeq.Empty

--- a/web/webkit/src/main/scala/net/liftweb/builtin/snippet/WithResourceId.scala
+++ b/web/webkit/src/main/scala/net/liftweb/builtin/snippet/WithResourceId.scala
@@ -52,14 +52,14 @@ object WithResourceId extends DispatchSnippet {
              MetaData.update(attrs, 
                              scope, 
                              new UnprefixedAttribute("href", LiftRules.attachResourceId(href), Null)),
-             scope, childs: _*)) openOr e
+             scope, minimizeEmpty = false, childs: _*)) openOr e
      case e @ Elem(prefix, "script", attrs, scope, childs @ _*) => 
         attrStr(attrs, "src") map (src =>
         Elem(prefix, "script", 
              MetaData.update(attrs, 
                              scope, 
                              new UnprefixedAttribute("src", LiftRules.attachResourceId(src), Null)),
-             scope, childs: _*)) openOr e
+             scope, minimizeEmpty = false, childs: _*)) openOr e
      case e => e
     })
   }

--- a/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/CometActor.scala
@@ -685,7 +685,7 @@ trait CometActor extends LiftActor with LiftCometActor with BindHelpers {
    */
   def buildSpan(time: Long, xml: NodeSeq): NodeSeq = {
     Elem(parentTag.prefix, parentTag.label, parentTag.attributes,
-      parentTag.scope, Group(xml)) %
+      parentTag.scope, parentTag.minimizeEmpty, Group(xml)) %
       new UnprefixedAttribute("id",
         Text(spanId),
         if (time > 0L) {

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftMerge.scala
@@ -144,11 +144,11 @@ private[http] trait LiftMerge {
                       node <- _fixHtml(nodes, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy)
                     } yield node
 
-                  case e: Elem if e.label == "form" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "action", v.attributes, true), v.scope, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
-                  case e: Elem if e.label == "script" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "src", v.attributes, false), v.scope, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
-                  case e: Elem if e.label == "a" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "href", v.attributes, true), v.scope, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
-                  case e: Elem if e.label == "link" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "href", v.attributes, false), v.scope, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
-                  case e: Elem => Elem(v.prefix, v.label, fixAttrs(v.attributes, "src", v.attributes, true), v.scope, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
+                  case e: Elem if e.label == "form" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "action", v.attributes, true), v.scope, e.minimizeEmpty, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
+                  case e: Elem if e.label == "script" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "src", v.attributes, false), v.scope, e.minimizeEmpty, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
+                  case e: Elem if e.label == "a" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "href", v.attributes, true), v.scope, e.minimizeEmpty, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
+                  case e: Elem if e.label == "link" => Elem(v.prefix, v.label, fixAttrs(v.attributes, "href", v.attributes, false), v.scope, e.minimizeEmpty, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
+                  case e: Elem => Elem(v.prefix, v.label, fixAttrs(v.attributes, "src", v.attributes, true), v.scope, e.minimizeEmpty, _fixHtml(v.child, inHtml, inHead, justHead, inBody, justBody, bodyHead, bodyTail, doMergy): _*)
                   case c: Comment if stripComments => NodeSeq.Empty
                   case _ => v
                 }
@@ -233,12 +233,12 @@ private[http] trait LiftMerge {
       }
 
       htmlKids += nl
-      htmlKids += Elem(headTag.prefix, headTag.label, headTag.attributes, headTag.scope, headChildren.toList: _*)
+      htmlKids += Elem(headTag.prefix, headTag.label, headTag.attributes, headTag.scope, headTag.minimizeEmpty, headChildren.toList: _*)
       htmlKids += nl
-      htmlKids += Elem(bodyTag.prefix, bodyTag.label, bodyTag.attributes, bodyTag.scope, bodyChildren.toList: _*)
+      htmlKids += Elem(bodyTag.prefix, bodyTag.label, bodyTag.attributes, bodyTag.scope, bodyTag.minimizeEmpty, bodyChildren.toList: _*)
       htmlKids += nl
 
-      val tmpRet = Elem(htmlTag.prefix, htmlTag.label, htmlTag.attributes, htmlTag.scope, htmlKids.toList: _*)
+      val tmpRet = Elem(htmlTag.prefix, htmlTag.label, htmlTag.attributes, htmlTag.scope, htmlTag.minimizeEmpty, htmlKids.toList: _*)
 
       val ret: Node = if (Props.devMode) {
         LiftRules.xhtmlValidator.toList.flatMap(_(tmpRet)) match {
@@ -252,7 +252,7 @@ private[http] trait LiftMerge {
             val rule = new RewriteRule {
               override def transform(n: Node) = n match {
                 case e: Elem if e.label == "body" =>
-                  Elem(e.prefix, e.label, e.attributes, e.scope, e.child ++ errors: _*)
+                  Elem(e.prefix, e.label, e.attributes, e.scope, e.minimizeEmpty, e.child ++ errors: _*)
 
                 case x => super.transform(x)
               }

--- a/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala
@@ -2063,7 +2063,7 @@ class LiftSession(private[http] val _contextPath: String, val uniqueId: String,
 
         case v: Elem =>
           Elem(v.prefix, v.label, processAttributes(v.attributes, this.allowAttributeProcessing.is),
-            v.scope, processSurroundAndInclude(page, v.child): _*)
+            v.scope, v.minimizeEmpty, processSurroundAndInclude(page, v.child): _*)
 
         case pcd: scala.xml.PCData => pcd
         case text: Text => text
@@ -2468,7 +2468,7 @@ private object SnippetNode {
         } yield {
           val (par, nonLift) = liftAttrsAndParallel(elm.attributes)
           val newElm = new Elem(elm.prefix, elm.label,
-            nonLift, elm.scope, elm.child: _*)
+            nonLift, elm.scope, elm.minimizeEmpty, elm.child: _*)
           (newElm, newElm, par ||
             (lift.find {
               case up: UnprefixedAttribute if up.key == "parallel" => true

--- a/web/webkit/src/main/scala/net/liftweb/http/Req.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/Req.scala
@@ -581,11 +581,11 @@ object Req {
         v =>
         v match {
           case Group(nodes) => Group(_fixHtml(contextPath, nodes))
-          case e: Elem if e.label == "form" => Elem(v.prefix, v.label, fixAttrs("action", v.attributes, true), v.scope, _fixHtml(contextPath, v.child): _*)
-          case e: Elem if e.label == "script" => Elem(v.prefix, v.label, fixAttrs("src", v.attributes, false), v.scope, _fixHtml(contextPath, v.child): _*)
-          case e: Elem if e.label == "a" => Elem(v.prefix, v.label, fixAttrs("href", v.attributes, true), v.scope, _fixHtml(contextPath, v.child): _*)
-          case e: Elem if e.label == "link" => Elem(v.prefix, v.label, fixAttrs("href", v.attributes, false), v.scope, _fixHtml(contextPath, v.child): _*)
-          case e: Elem => Elem(v.prefix, v.label, fixAttrs("src", v.attributes, true), v.scope, _fixHtml(contextPath, v.child): _*)
+          case e: Elem if e.label == "form" => Elem(v.prefix, v.label, fixAttrs("action", v.attributes, true), v.scope, e.minimizeEmpty, _fixHtml(contextPath, v.child): _*)
+          case e: Elem if e.label == "script" => Elem(v.prefix, v.label, fixAttrs("src", v.attributes, false), v.scope, e.minimizeEmpty, _fixHtml(contextPath, v.child): _*)
+          case e: Elem if e.label == "a" => Elem(v.prefix, v.label, fixAttrs("href", v.attributes, true), v.scope, e.minimizeEmpty, _fixHtml(contextPath, v.child): _*)
+          case e: Elem if e.label == "link" => Elem(v.prefix, v.label, fixAttrs("href", v.attributes, false), v.scope, e.minimizeEmpty, _fixHtml(contextPath, v.child): _*)
+          case e: Elem => Elem(v.prefix, v.label, fixAttrs("src", v.attributes, true), v.scope, e.minimizeEmpty, _fixHtml(contextPath, v.child): _*)
           case _ => v
         }
       }

--- a/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/SHtml.scala
@@ -103,7 +103,7 @@ trait SHtml {
       case e: Elem => val updated = elemAttrs.foldLeft(e)((e, f) => f(e))
 
         new Elem(updated.prefix, updated.label,
-                               updated.attributes, updated.scope,
+                               updated.attributes, updated.scope, updated.minimizeEmpty,
                                applyToAllElems(updated.child, elemAttrs) :_*)
       case n => n
     }
@@ -371,6 +371,7 @@ trait SHtml {
                  latestElem.label,
                  latestElem.attributes,
                  latestElem.scope,
+                 latestElem.minimizeEmpty,
                  f(this)(latestKids) :_*)
 
       def setHtml(): JsCmd = SetHtml(latestId, f(this)(latestKids))
@@ -1057,7 +1058,7 @@ trait SHtml {
     (elem \ "@onblur").toList match {
       case Nil => elem % ("onblur" -> blurCmd)
       case x :: xs => val attrs = elem.attributes.filter(_.key != "onblur")
-      Elem(elem.prefix, elem.label, new UnprefixedAttribute("onblur", Text(blurCmd + x.text), attrs), elem.scope, elem.child: _*)
+      Elem(elem.prefix, elem.label, new UnprefixedAttribute("onblur", Text(blurCmd + x.text), attrs), elem.scope, elem.minimizeEmpty, elem.child: _*)
     }
   }
 
@@ -1128,6 +1129,7 @@ trait SHtml {
                                        case _ => true
                                      }),
              elem.scope,
+             elem.minimizeEmpty,
              elem.child :_*)
   }
 
@@ -1178,7 +1180,7 @@ trait SHtml {
                                                                      funcName+"=_"),
                                                      meta)
 
-                         }, e.scope, e.child :_*)
+                         }, e.scope, e.minimizeEmpty, e.child :_*)
             }
           }
 
@@ -1254,7 +1256,7 @@ trait SHtml {
                                                  cmd,
                                                  meta)
 
-                     }, e.scope, e.child :_*)
+                     }, e.scope, e.minimizeEmpty, e.child :_*)
           }
 
 
@@ -1785,7 +1787,7 @@ trait SHtml {
         }
 
         new Elem(e.prefix, e.label,
-                 newMeta, e.scope, e.child :_*) % ("id" -> id) %
+                 newMeta, e.scope, e.minimizeEmpty, e.child :_*) % ("id" -> id) %
         ("action" -> "javascript://") %
         ("onsubmit" ->
          (SHtml.makeAjaxCall(LiftRules.jsArtifacts.serialize(id)).toJsCmd +

--- a/web/webkit/src/main/scala/net/liftweb/http/WiringUI.scala
+++ b/web/webkit/src/main/scala/net/liftweb/http/WiringUI.scala
@@ -133,7 +133,7 @@ object WiringUI {
       new Elem(myElem.prefix,
                myElem.label,
                myElem.attributes,
-               myElem.scope)
+               myElem.scope, myElem.minimizeEmpty)
     }
 
 


### PR DESCRIPTION
I'm guessing we will merge this back into the v2.6.3_scala2.13 branch? It'll get awkward if we try to merge in more recent versions of Lift into this, but instead of doing that, let's like remove Lift from the codebase...

See comment on ticket for more about the general changes made in this ticket: https://paytronix.atlassian.net/browse/PXS-80852?focusedCommentId=753518